### PR TITLE
fix: op_overloading example

### DIFF
--- a/content/examples/op_overloading.md
+++ b/content/examples/op_overloading.md
@@ -9,9 +9,10 @@ Operator overloading is possible in Cairo through the use of particular traits, 
 For example, for overloading the addition (+) operator of a `Vector2` type:
 
 ```rust {.codebox}
+#[derive(PartialEq, Drop)]
 struct Vector2 {
-    x: f32,
-    y: f32,
+    x: felt252,
+    y: felt252,
 }
 
 impl Vector2Add of Add<Vector2> {


### PR DESCRIPTION
Fix op_overloading example
https://github.com/lambdaclass/cairo-by-example/issues/44#issue-1771731705