### PR TITLE
Add `.PHONY` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build serve
+
 build:
 	hugo
 


### PR DESCRIPTION
As we now have a _build_ directory, `make` confuses it with the `build` target