### PR TITLE
Add debian dpkg-buildpackage build files

### DIFF
--- a/build/debian/README.md
+++ b/build/debian/README.md
@@ -1,0 +1,1 @@
+# Cairo deb package builder files

--- a/build/debian/cairo-2.0.0-rc4/Makefile
+++ b/build/debian/cairo-2.0.0-rc4/Makefile
@@ -1,0 +1,25 @@
+.PHONY: install uninstall
+
+prefix = /usr
+
+install:
+	rustup override set stable
+	cargo build --all --release --manifest-path ./Cargo.toml
+	install -D ./target/release/cairo-compile $(DESTDIR)$(prefix)/bin/cairo-compile
+	install -D ./target/release/cairo-format $(DESTDIR)$(prefix)/bin/cairo-format
+	install -D ./target/release/cairo-language-server $(DESTDIR)$(prefix)/bin/cairo-language-server
+	install -D ./target/release/cairo-run $(DESTDIR)$(prefix)/bin/cairo-run
+	install -D ./target/release/cairo-test $(DESTDIR)$(prefix)/bin/cairo-test
+	install -D ./target/release/sierra-compile $(DESTDIR)$(prefix)/bin/sierra-compile
+	install -D ./target/release/starknet-compile $(DESTDIR)$(prefix)/bin/starknet-compile
+	install -D ./target/release/starknet-sierra-compile $(DESTDIR)$(prefix)/bin/starknet-sierra-compile
+
+uninstall:
+	-rm -f $(DESTDIR)$(prefix)/bin/cairo-compile
+	-rm -f $(DESTDIR)$(prefix)/bin/cairo-format
+	-rm -f $(DESTDIR)$(prefix)/bin/cairo-language-server
+	-rm -f $(DESTDIR)$(prefix)/bin/cairo-run
+	-rm -f $(DESTDIR)$(prefix)/bin/cairo-test
+	-rm -f $(DESTDIR)$(prefix)/bin/sierra-compile
+	-rm -f $(DESTDIR)$(prefix)/bin/starknet-compile
+	-rm -f $(DESTDIR)$(prefix)/bin/starknet-sierra-compile

--- a/build/debian/cairo-2.0.0-rc4/debian/control
+++ b/build/debian/cairo-2.0.0-rc4/debian/control
@@ -1,0 +1,17 @@
+Source: cairo
+Section: unknown
+Priority: optional
+Maintainer: LambdaClass <infra@lambdaclass.com>
+Build-Depends: debhelper-compat (= 13)
+Standards-Version: 4.5.1
+Homepage: https://starkware.co/cairo/
+Vcs-Browser: https://github.com/starkware-libs/cairo
+Vcs-Git: https://github.com/starkware-libs/cairo.git
+Rules-Requires-Root: no
+
+Package: cairo
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Cairo programming language
+ Cairo is the first Turing-complete language for creating provable programs for
+ general computation

--- a/build/debian/cairo-2.0.0-rc4/debian/patches/add-makefile
+++ b/build/debian/cairo-2.0.0-rc4/debian/patches/add-makefile
@@ -1,0 +1,39 @@
+Description: Add required Makefile for dpkg-buildpackage
+ Makefile created using format from:
+ https://www.debian.org/doc/manuals/debmake-doc/ch04.en.html#step-upstream
+ It's required to create a .deb package for debian systems
+ .
+ cairo (2.0.0-rc4-1) unstable; urgency=medium
+ .
+Author: LambdaClass <infra@lambdaclass.com>
+
+---
+
+--- /dev/null
++++ cairo-2.0.0-rc4/Makefile
+@@ -0,0 +1,25 @@
++.PHONY: install uninstall
++
++prefix = /usr
++
++install:
++	rustup override set stable
++	cargo build --all --release --manifest-path ./Cargo.toml
++	install -D ./target/release/cairo-compile $(DESTDIR)$(prefix)/bin/cairo-compile
++	install -D ./target/release/cairo-format $(DESTDIR)$(prefix)/bin/cairo-format
++	install -D ./target/release/cairo-language-server $(DESTDIR)$(prefix)/bin/cairo-language-server
++	install -D ./target/release/cairo-run $(DESTDIR)$(prefix)/bin/cairo-run
++	install -D ./target/release/cairo-test $(DESTDIR)$(prefix)/bin/cairo-test
++	install -D ./target/release/sierra-compile $(DESTDIR)$(prefix)/bin/sierra-compile
++	install -D ./target/release/starknet-compile $(DESTDIR)$(prefix)/bin/starknet-compile
++	install -D ./target/release/starknet-sierra-compile $(DESTDIR)$(prefix)/bin/starknet-sierra-compile
++
++uninstall:
++	-rm -f $(DESTDIR)$(prefix)/bin/cairo-compile
++	-rm -f $(DESTDIR)$(prefix)/bin/cairo-format
++	-rm -f $(DESTDIR)$(prefix)/bin/cairo-language-server
++	-rm -f $(DESTDIR)$(prefix)/bin/cairo-run
++	-rm -f $(DESTDIR)$(prefix)/bin/cairo-test
++	-rm -f $(DESTDIR)$(prefix)/bin/sierra-compile
++	-rm -f $(DESTDIR)$(prefix)/bin/starknet-compile
++	-rm -f $(DESTDIR)$(prefix)/bin/starknet-sierra-compile

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,10 @@
   Download the package with your favourite AUR helper, such as <a href="https://github.com/Jguer/yay"> yay</a>:
   <pre><code>yay -S cairo-lang</code></pre>
 
+  <h4>Debian 11</h4>
+  Download the pre-compiled debian package from cairo-by-example repository and install it using dpkg:
+  <pre><code>wget -O /tmp/cairo_2.0.0-rc4-1_amd64.deb https://github.com/lambdaclass/cairo-by-example/releases/download/v2.0.0-rc4/cairo_2.0.0-rc4-1_amd64.deb && dpkg -i /tmp/cairo_2.0.0-rc4-1_amd64.deb</code></pre>
+
   <h4>Other Linux</h4>
   Requirements: <code>git</code>, <code>rustup</code>
   <pre><code>curl -L https://github.com/franalgaba/cairo-installer/raw/main/bin/cairo-installer | bash</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
 
   <h4>MacOS</h4>
   Download custom Homebrew formulae and use it to install cairo-lang:
-  <pre><code>curl -o /tmp/cairo-lang.rb https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/homebrew/cairo-lang.rb && brew install --formula --build-from-source /tmp/cairo-lang.rb</code></pre>
+  <pre><code>curl -o /tmp/cairo-lang.rb https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/build/homebrew/cairo-lang.rb && brew install --formula --build-from-source /tmp/cairo-lang.rb</code></pre>
 
   <h4>Arch Linux</h4>
   Download the package with your favourite AUR helper, such as <a href="https://github.com/Jguer/yay"> yay</a>:
@@ -54,6 +54,14 @@
       </li>
       
       <li>
+        <a href="https://cairo-by-example.com/examples/strings/" style="text-transform: capitalize;">strings</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/clone_and_copy/" style="text-transform: capitalize;">clone and copy</a>
+      </li>
+      
+      <li>
         <a href="https://cairo-by-example.com/examples/hello-world/" style="text-transform: capitalize;">hello world</a>
       </li>
       
@@ -62,67 +70,11 @@
       </li>
       
       <li>
-        <a href="https://cairo-by-example.com/examples/variables/" style="text-transform: capitalize;">variables</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/loop/" style="text-transform: capitalize;">loop</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/op_overloading/" style="text-transform: capitalize;">operator overloading</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/strings/" style="text-transform: capitalize;">strings</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/tuples/" style="text-transform: capitalize;">tuples</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/enums/" style="text-transform: capitalize;">enums</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/zeroable/" style="text-transform: capitalize;">zeroable</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/snapshots/" style="text-transform: capitalize;">snapshots</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/testing/" style="text-transform: capitalize;">testing</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/pattern_matching/" style="text-transform: capitalize;">pattern_matching</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/structs/" style="text-transform: capitalize;">structs</a>
-      </li>
-      
-      <li>
         <a href="https://cairo-by-example.com/examples/comments/" style="text-transform: capitalize;">comments</a>
       </li>
       
       <li>
-        <a href="https://cairo-by-example.com/examples/dictionaries/" style="text-transform: capitalize;">dictionaries</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/arrays/" style="text-transform: capitalize;">arrays</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/ownership/" style="text-transform: capitalize;">ownership</a>
-      </li>
-      
-      <li>
-        <a href="https://cairo-by-example.com/examples/functions/" style="text-transform: capitalize;">functions</a>
+        <a href="https://cairo-by-example.com/examples/variables/" style="text-transform: capitalize;">variables</a>
       </li>
       
       <li>
@@ -134,11 +86,51 @@
       </li>
       
       <li>
+        <a href="https://cairo-by-example.com/examples/integers/" style="text-transform: capitalize;">integers</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/arrays/" style="text-transform: capitalize;">arrays</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/structs/" style="text-transform: capitalize;">structs</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/enums/" style="text-transform: capitalize;">enums</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/tuples/" style="text-transform: capitalize;">tuples</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/dictionaries/" style="text-transform: capitalize;">dictionaries</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/functions/" style="text-transform: capitalize;">functions</a>
+      </li>
+      
+      <li>
         <a href="https://cairo-by-example.com/examples/if/" style="text-transform: capitalize;">if expression</a>
       </li>
       
       <li>
-        <a href="https://cairo-by-example.com/examples/clone_and_copy/" style="text-transform: capitalize;">clone and copy</a>
+        <a href="https://cairo-by-example.com/examples/loop/" style="text-transform: capitalize;">loop</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/ownership/" style="text-transform: capitalize;">ownership</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/snapshots/" style="text-transform: capitalize;">snapshots</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/pattern_matching/" style="text-transform: capitalize;">pattern_matching</a>
       </li>
       
       <li>
@@ -146,7 +138,15 @@
       </li>
       
       <li>
-        <a href="https://cairo-by-example.com/examples/integers/" style="text-transform: capitalize;">integers</a>
+        <a href="https://cairo-by-example.com/examples/testing/" style="text-transform: capitalize;">testing</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/op_overloading/" style="text-transform: capitalize;">operator overloading</a>
+      </li>
+      
+      <li>
+        <a href="https://cairo-by-example.com/examples/zeroable/" style="text-transform: capitalize;">zeroable</a>
       </li>
       
     </ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 
   <h4>MacOS</h4>
   Download custom Homebrew formulae and use it to install cairo-lang:
-  <pre><code>curl -o /tmp/cairo-lang.rb https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/homebrew/cairo-lang.rb && brew install --formula --build-from-source /tmp/cairo-lang.rb</code></pre>
+  <pre><code>curl -o /tmp/cairo-lang.rb https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/build/homebrew/cairo-lang.rb && brew install --formula --build-from-source /tmp/cairo-lang.rb</code></pre>
 
   <h4>Arch Linux</h4>
   Download the package with your favourite AUR helper, such as <a href="https://github.com/Jguer/yay"> yay</a>:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,10 @@
   Download the package with your favourite AUR helper, such as <a href="https://github.com/Jguer/yay"> yay</a>:
   <pre><code>yay -S cairo-lang</code></pre>
 
+  <h4>Debian 11</h4>
+  Download the pre-compiled debian package from cairo-by-example repository and install it using dpkg:
+  <pre><code>wget -O /tmp/cairo_2.0.0-rc4-1_amd64.deb https://github.com/lambdaclass/cairo-by-example/releases/download/v2.0.0-rc4/cairo_2.0.0-rc4-1_amd64.deb && dpkg -i /tmp/cairo_2.0.0-rc4-1_amd64.deb</code></pre>
+
   <h4>Other Linux</h4>
   Requirements: <code>git</code>, <code>rustup</code>
   <pre><code>curl -L https://github.com/franalgaba/cairo-installer/raw/main/bin/cairo-installer | bash</code></pre>


### PR DESCRIPTION
To build the package:

```shell
export DEBEMAIL="infra@lambdaclass.com"
export DEBFULLNAME="LambdaClass"
wget https://github.com/starkware-libs/cairo/archive/refs/tags/v2.0.0-rc4.tar.gz
cd cairo-2.0.0-rc4/
dh_make --createorig
# Add Makefile
dpkg-source --commit
dpkg-buildpackage
```
`cairo_2.0.0-rc4-1_amd64.deb` should be generated