### PR TITLE
Intro change to 'minutes' for more clear

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,7 +19,7 @@
 
   <h4>An introduction to <a href="https://cairo-lang.org/">Cairo</a>, with simple examples. </h4>
   The objective of this tutorial is to quickly on-board new developers to Cairo. The first experience newcomers have
-  with Cairo and Starknet should be smooth and in 15' they should have everything setup and a good overview on what the
+  with Cairo and Starknet should be smooth and in 15 minutes they should have everything setup and a good overview on what the
   language is all about.
   <h4>Examples:</h4>
   <div class="resource-list">


### PR DESCRIPTION
After showing the tutorial to someone from a country that uses the Imperial unit system, he suggested we should change `15'` to `15 minutes` to avoid confusion.