### PR TITLE
Fix: choose next in weight ascending order

### DIFF
--- a/layouts/examples/single.html
+++ b/layouts/examples/single.html
@@ -17,8 +17,8 @@
 </details>
 <br>
 
-{{- $prev := .PrevInSection }}
-{{- $next := .NextInSection }}
+{{- $prev := .NextInSection }}
+{{- $next := .PrevInSection }}
 <div style="display: flex; justify-content: space-between;">
     {{- if $prev }}
     <a href="{{ $prev.Permalink }}">prev ({{ $prev.Title }})</a>


### PR DESCRIPTION
Currently, examples have the _prev_ and _next_ buttons reversed. This PR fixes that