### PR TITLE
Fix dict example

### DIFF
--- a/content/en/examples/dictionaries.md
+++ b/content/en/examples/dictionaries.md
@@ -12,7 +12,7 @@ By default, the value `0` is returned for non-existing keys:
 ```rust {.codebox}
     use dict::Felt252DictTrait;
 
-    fn test_dict() -> felt252 {
+    fn main() -> felt252 {
         let mut dict_u8 = felt252_dict_new::<u8>();
         let mut dict_felt = felt252_dict_new::<felt252>();
         dict_u8.insert(10, 110);
@@ -20,6 +20,6 @@ By default, the value `0` is returned for non-existing keys:
         let val10 = dict_u8[10]; // 110
         let val11 = dict_felt[11]; // 0
         dict_felt.insert(11, 1024);
-        let val11 = dict_felt[11]; // 1024
+        dict_felt[11] // 1024
     }
 ```

--- a/content/es/examples/dictionaries.md
+++ b/content/es/examples/dictionaries.md
@@ -12,7 +12,7 @@ Por defecto, se devuelve el valor `0` para claves no existentes:
 ```rust {.codebox}
     use dict::Felt252DictTrait;
 
-    fn test_dict() -> felt252 {
+    fn main() -> felt252 {
         let mut dict_u8 = felt252_dict_new::<u8>();
         let mut dict_felt = felt252_dict_new::<felt252>();
         dict_u8.insert(10, 110);
@@ -20,6 +20,6 @@ Por defecto, se devuelve el valor `0` para claves no existentes:
         let val10 = dict_u8[10]; // 110
         let val11 = dict_felt[11]; // 0
         dict_felt.insert(11, 1024);
-        let val11 = dict_felt[11]; // 1024
+        dict_felt[11] // 1024
     }
 ```


### PR DESCRIPTION
Includes a fix for the dictionary example for both languages. The problem was that the function was expecting to return a `felt252` but the last line ended with a semicolon. Also the name was changed to `main`.