### PR TITLE
Fix array example

### DIFF
--- a/content/en/examples/arrays.md
+++ b/content/en/examples/arrays.md
@@ -14,7 +14,7 @@ fn get_array() -> Array<felt252> {
     numbers.append(444);
     numbers.append(555);
 
-    return numbers;
+    numbers
 }
 ```
 
@@ -57,7 +57,7 @@ fn get_array() -> Array<felt252> {
     numbers.append(444);
     numbers.append(555);
 
-    return numbers;
+    numbers
 }
 
 #[test]

--- a/content/es/examples/arrays.md
+++ b/content/es/examples/arrays.md
@@ -14,7 +14,7 @@ fn get_array() -> Array<felt252> {
     numbers.append(444);
     numbers.append(555);
 
-    return numbers;
+    numbers
 }
 ```
 
@@ -57,7 +57,7 @@ fn get_array() -> Array<felt252> {
     numbers.append(444);
     numbers.append(555);
 
-    return numbers;
+    numbers
 }
 
 #[test]


### PR DESCRIPTION
Includes a fix to the `get_array` function.