### PR TITLE
Add full example for pattern matching

### DIFF
--- a/content/en/examples/pattern_matching.md
+++ b/content/en/examples/pattern_matching.md
@@ -44,3 +44,41 @@ fn match_my_struct(s: MyStruct) -> u16 {
     }
 }
 ```
+Here is the full example:
+```rust {.codebox}
+struct MyStruct {
+    a: u16,
+    b: u16,
+}
+
+fn destructure_my_struct(s: MyStruct, t: MyStruct, u: MyStruct) -> u16 {
+    // We can ignore a single field by using `_` or `_name`
+    let MyStruct{a: a, b: _b} = u;
+    let MyStruct{a: b, b: _} = s;
+    // Or just ignore everything we didn't name by using `..` at the end
+    let MyStruct{b: c, ..} = t;
+    a + b + c
+}
+
+fn destructure_tuple(t: (u16, u16)) -> u16 {
+    let (x, y) = t;
+    x + y
+}
+
+#[test]
+fn test_destructure_struct(){
+    let s = MyStruct{a: 1, b: 2};
+    let t = MyStruct{a: 3, b: 4};
+    let u = MyStruct{a: 5, b: 6};
+    let sum = destructure_my_struct(s, t, u);
+    assert(sum == 10, 'sum should be 10');
+}
+
+#[test]
+fn test_destructure_tuple(){
+    let t = (1, 2);
+    let sum = destructure_tuple(t);
+    assert(sum == 3, 'sum should be 3');
+}
+```
+To try it out you can run `cairo-test pattern_matching.cairo` on your terminal.

--- a/content/es/examples/pattern_matching.md
+++ b/content/es/examples/pattern_matching.md
@@ -44,3 +44,41 @@ fn match_my_struct(s: MyStruct) -> u16 {
     }
 }
 ```
+Ejemplo completo:
+```rust {.codebox}
+struct MyStruct {
+    a: u16,
+    b: u16,
+}
+
+fn destructure_my_struct(s: MyStruct, t: MyStruct, u: MyStruct) -> u16 {
+    // We can ignore a single field by using `_` or `_name`
+    let MyStruct{a: a, b: _b} = u;
+    let MyStruct{a: b, b: _} = s;
+    // Or just ignore everything we didn't name by using `..` at the end
+    let MyStruct{b: c, ..} = t;
+    a + b + c
+}
+
+fn destructure_tuple(t: (u16, u16)) -> u16 {
+    let (x, y) = t;
+    x + y
+}
+
+#[test]
+fn test_destructure_struct(){
+    let s = MyStruct{a: 1, b: 2};
+    let t = MyStruct{a: 3, b: 4};
+    let u = MyStruct{a: 5, b: 6};
+    let sum = destructure_my_struct(s, t, u);
+    assert(sum == 10, 'sum should be 10');
+}
+
+#[test]
+fn test_destructure_tuple(){
+    let t = (1, 2);
+    let sum = destructure_tuple(t);
+    assert(sum == 3, 'sum should be 3');
+}
+```
+Para correrlo puedes ejecutar `cairo-test pattern_matching.cairo` en tu terminal


### PR DESCRIPTION
Adds the full example at the end of the page. This way users can copy, paste and try out the code easier.