### PR TITLE
fixed archlinux corelib/ installation

### DIFF
--- a/build/arch/.SRCINFO
+++ b/build/arch/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cairo-lang
 	pkgdesc = Cairo language installation
 	pkgver = 2.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://cairo-by-example.com/
 	arch = x86_64
 	license = MIT

--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -36,13 +36,21 @@ build() {
 }
 
 package() {
+	mkdir -p $pkgdir/usr/bin/ $pkgdir/usr/lib/
+
+	mv cairo-$pkgver-$release/corelib/ $pkgdir/usr/lib/
 	
 	pkgs=("cairo-run" "cairo-compile" "cairo-format" "cairo-language-server" "cairo-test" "sierra-compile" "starknet-compile" "starknet-sierra-compile")
 	
-	mkdir -p $pkgdir/usr/bin/
-	
 	for pkg in ${pkgs[@]}; do
-		mv cairo-$pkgver-$release/target/release/$pkg $pkgdir/usr/bin
+		mv cairo-$pkgver-$release/target/release/$pkg $pkgdir/usr/bin/
 	done
+	
+	add_to_config
 }
 
+add_to_config() {
+	declare -A shells=( ["bash"]=".bashrc" ["fish"]=".config/fish/config.fish" ["zsh"]=".zshrc")
+
+	echo "export CARGO_MANIFEST_DIR=\"/usr/bin/corelib/\"" >> /home/$USER/${shells[$(basename $(echo $SHELL))]}
+}

--- a/build/installer.sh
+++ b/build/installer.sh
@@ -51,7 +51,7 @@ case "$os" in
 		case "$ID" in
 			# XXX: Script for debian/ubuntu is not working (missing corelib/)
 			arch)
-			echo -e "${YEL}--- Installing Cairo ${version} on Arch Linux --- ${RST}"
+				echo -e "${YEL}--- Installing Cairo ${version} on Arch Linux --- ${RST}"
 				[[ ! -e /usr/bin/yay ]] && echo -e "${ERR}No yay installation found. If you use another AUR helper, please install the cairo-lang package.${RST}"
 				set -x
 				yay -S cairo-lang

--- a/build/installer.sh
+++ b/build/installer.sh
@@ -49,14 +49,14 @@ case "$os" in
 		[[ ! -e /etc/os-release ]] && exit 1
 		source /etc/os-release
 		case "$ID" in
-			# XXX: Scripts for arch and debian/ubuntu are not working (missing corelib/)
-			# arch)
-			# 	echo -e "${YEL}--- Installing Cairo ${version} on Arch Linux --- ${RST}"
-			# 	[[ ! -e /usr/bin/yay ]] && echo -e "${ERR}No yay installation found. If you use another AUR helper, please install the cairo-lang package.${RST}"
-			# 	set -x
-			# 	yay -S cairo-lang
-			# 	set +x
-			# 	;;
+			# XXX: Script for debian/ubuntu is not working (missing corelib/)
+			arch)
+			echo -e "${YEL}--- Installing Cairo ${version} on Arch Linux --- ${RST}"
+				[[ ! -e /usr/bin/yay ]] && echo -e "${ERR}No yay installation found. If you use another AUR helper, please install the cairo-lang package.${RST}"
+				set -x
+				yay -S cairo-lang
+				set +x
+				;;
 			# debian | ubuntu)
 			# 	[[ ! -e /etc/os-release ]] && exit 1
 			# 	echo -e "${YEL}--- Installing Cairo ${version} on Debian/Ubuntu --- ${RST}"


### PR DESCRIPTION
Fixed arch's package not working due to not proper `corelib` directory installation.