### PR TITLE
Update footer

### DIFF
--- a/content/en/examples/hello-world.md
+++ b/content/en/examples/hello-world.md
@@ -2,6 +2,7 @@
 title: "hello world"
 weight: 10
 draft: false
+example_type: "main"
 ---
 
 the `use` keyword imports a dependency into scope

--- a/content/en/examples/hello-world.md
+++ b/content/en/examples/hello-world.md
@@ -2,7 +2,7 @@
 title: "hello world"
 weight: 10
 draft: false
-run_command: "cairo-run hello_world.cairo"
+run_command: "cairo-run"
 ---
 
 the `use` keyword imports a dependency into scope

--- a/content/en/examples/hello-world.md
+++ b/content/en/examples/hello-world.md
@@ -14,9 +14,7 @@ fn main() {
     'Hello, world!'.print();
 }
 ```
-
-now, run the tests with `cairo-run hello_world.cairo`
-
+running this will yield:
 ```bash
 [DEBUG] Hello, world!                   (raw: 5735816763073854953388147237921)
 

--- a/content/en/examples/hello-world.md
+++ b/content/en/examples/hello-world.md
@@ -2,7 +2,7 @@
 title: "hello world"
 weight: 10
 draft: false
-example_type: "main"
+run_command: "cairo-run hello_world.cairo"
 ---
 
 the `use` keyword imports a dependency into scope

--- a/layouts/examples/single.html
+++ b/layouts/examples/single.html
@@ -4,11 +4,32 @@
 <br>
 <hr>
 <details>
-    <summary><i>How to install the toolchain</i></summary>
-    <br>
-    For macOS and Linux, run our script:
-    <pre>curl -L https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/build/installer.sh | bash</pre>
-  For Windows and others, please see <a href="https://www.cairo-lang.org/docs/getting_started/prerequisits.html">the official guide</a>
+    <summary><i>Try it out!</i></summary>
+    <ol>
+      <li>
+      Install the toolchain:<br>
+        <ul>
+          <li>
+            For macOS and Linux, run our script:
+          </li>
+            <pre>curl -L https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/build/installer.sh | bash</pre>
+          <li>
+            For Windows and others, please see <a href="https://www.cairo-lang.org/docs/getting_started/prerequisits.html">the official guide</a>
+          </li>
+        </ul>
+      </li>
+      <li>
+      Run the example:
+      <ol>
+        <li>Copy the example into a <b><i>filename</i>.cairo</b> file and run with:</li>
+        {{ if eq .Params.example_type "main" }}
+          <pre>cairo-run <i>filename</i>.cairo</pre>
+        {{ else if eq .Params.example_type "test" }}
+          <pre>cairo-test <i>filename</i>.cairo</pre>
+        {{ end }}
+      </ol>
+      </li>
+    </ol>
 </details>
 <br>
 

--- a/layouts/examples/single.html
+++ b/layouts/examples/single.html
@@ -1,19 +1,14 @@
 {{ define "main" }}
 <h3>{{ .Title }}</h3>
 {{ .Content }}
-
 <br>
+<hr>
 <details>
-    <summary><i>try it out</i></summary>
-
-    install the cairo toolchain if you haven't yet:
-    <pre>
-	curl -L https://github.com/franalgaba/cairo-installer/raw/main/bin/cairo-installer | bash
-        </pre>
-
-    then checkout and run the example:
-    <pre>
-        </pre>
+    <summary><i>How to install the toolchain</i></summary>
+    <br>
+    For macOS and Linux, run our script:
+    <pre>curl -L https://raw.githubusercontent.com/lambdaclass/cairo-by-example/main/build/installer.sh | bash</pre>
+  For Windows and others, please see <a href="https://www.cairo-lang.org/docs/getting_started/prerequisits.html">the official guide</a>
 </details>
 <br>
 

--- a/layouts/examples/single.html
+++ b/layouts/examples/single.html
@@ -21,8 +21,8 @@
       <li>
       Run the example:
       <ol>
-        <li>Copy the example into a <b><i>filename</i>.cairo</b> file and run with:</li>
-        <pre>{{ printf "%s" .Params.run_command }}</pre>
+        <li>Copy the example into a <b>{{ .File.BaseFileName}}.cairo</b> file and run with:</li>
+        <pre>{{ printf "%s" .Params.run_command }} {{ .File.BaseFileName }}.cairo</pre>
       </ol>
       </li>
     </ol>

--- a/layouts/examples/single.html
+++ b/layouts/examples/single.html
@@ -22,11 +22,7 @@
       Run the example:
       <ol>
         <li>Copy the example into a <b><i>filename</i>.cairo</b> file and run with:</li>
-        {{ if eq .Params.example_type "main" }}
-          <pre>cairo-run <i>filename</i>.cairo</pre>
-        {{ else if eq .Params.example_type "test" }}
-          <pre>cairo-test <i>filename</i>.cairo</pre>
-        {{ end }}
+        <pre>{{ printf "%s" .Params.run_command }}</pre>
       </ol>
       </li>
     </ol>


### PR DESCRIPTION
The current footer that appears on every example page is badly formatted and outdated, we have our own install script now. This PR fixes that.

Also, by suggestion of @MegaRedHand, a parametrized run step was added to replace some example's "run with this command" paragraph.