### PR TITLE
Added Open in Cairo Playground Links to Examples (Both en and es languages)

### DIFF
--- a/content/en/examples/arrays.md
+++ b/content/en/examples/arrays.md
@@ -83,3 +83,5 @@ fn test_array_retrieve_elements() {
     // array.at(2) will cause an error
 }
 ```
+
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27hagqAgvhoptionqOptionvhboxqBoxvkfn%20main%7B%7D%20-%3EY%3Cfelt252%3E%20(~let%20mut%20j%20%3DYZqnew%7Bz444z555_k~jk)%27~kccz_~j.append%7BvZ%3Bkq%3A%3Ak%5Cnjnumbershuse%20grrayc%20%20_%7D%3BZTraitY%20Ag%01YZ_cghjkqvz~_>)

--- a/content/en/examples/clone_and_copy.md
+++ b/content/en/examples/clone_and_copy.md
@@ -29,6 +29,9 @@ fn main() {
     // foo(arr); <- fails to compile, as main doesn't own the array anymore
 }
 ```
+
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%279HNuseOVZCVN9UTCVImplNqfF_%3A%20UM%7DGfoojakRB.~xwhenKisgreturns%2CDiLdropped.q)qqfnSQGasKeOreatorYfz%2CKeSgownsB~letD%3D%20HZMZnewQN~_.cVQXxmovRPOVYfzjogcallq~_XxcompileLbecause%20previouslyB%20waLduplicated~~x_X%3C-EailsjoOompile%2CPsS%20doesn%22tYwnBPnymoreq)%27~qJJzPrrx%2F%2F%20q%5Cnj%20tgEunctioF_foo%7BarrZ%3A%3AY%20oX%7D%3B%20WezayVloneUArrayS%20mainResYwnershipYfQ%7B%7DP%20aO%20cN%3BqM%3Cu128%3ELs%20KjhJ%20%20HUTraitG%20(~xFn%20E%20fDz%20BKW9usWZ%019BDEFGHJKLMNOPQRSUVWXYZ_gjqxz~_>)
+
 Try it out running `cairo-run --single-file clone_copy.cairo --available-gas 20000` in your terminal.
 
 An example of deriving the Copy trait:

--- a/content/en/examples/dictionaries.md
+++ b/content/en/examples/dictionaries.md
@@ -23,3 +23,5 @@ By default, the value `0` is returned for non-existing keys:
         dict_felt[11] // 1024
     }
 ```
+
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27use%20dSWFeltZDSTrait%3Bjjfn%20main%7B%7D%20-%3EQZ%20(bu8zu8XbqzqZX~yu8h0YUkjOUoyu8%5BU%5DP1UO11ogP0~yqh1Y024k~gxU24j)%27~jVVzoqZ_ynewW%3CydS_x%20%2F%2FQfeltp~leRo%20%3D%20k%7D%3Bj%5Cnh.insert%7B1gyq%5B11%5DbpmuRyZ252Y%2C%201X%3E%7BkW%3A%3AV%20%20U10SictRt%20Q%20qP%3BxOpval%01OPQRSUVWXYZbghjkopqxyz~_>)

--- a/content/en/examples/enums.md
+++ b/content/en/examples/enums.md
@@ -46,4 +46,7 @@ fn my_enum_get_b(x: MyEnum) -> Option::<u16> {
     }
 }
 ```
+
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27use%20optionkWTrait0use%20debugkPr!tTrait0ZDef!e5qenum%20YRAJu8LBJu16LCJu32LDJu64q)qZIKwill%20pr!KUqfn%20ma!XRleKx9VaX0~leKy9Vget_bF%7D0~mHyR~WkSomeFj%22GoKB%22.pr!tXL~*jU.pr!tXL)%20q)qZConstrucKand%20return5%20variant.qfnVaX%20-7YRYkA%7B4_u8%7Dq)qZMHtheQ%2C%20the%20order%20musKmHtheQ%20def!ition.ZW%20is%20also5.qfnVget_bFJY%7D%20-7Wk%3Cu16%3ERmHxR~YkAz~YkBFjWkSomeF%7DL~YkCz~YkDz)q)%27~%20%20%20%20zFj*%7DLq%5Cnk%3A%3Aj%7D97Zq%2F%2F%20YMyEnumX%7B%7DWOptionV%20my_enum_U%22GoKsometh!g%20else%22R%20(q~Q%20enumL%2Cq~Kt%20J%3A%20Hatch%20F%7Bx9%20%3D7%3E%205%20anQ0%3Bq*WkNone%7BX!in%01!*0579FHJKLQRUVWXYZjkqz~_>)
+
 To try the example simply run `cairo-run --single-file enums.cairo` in your terminal.

--- a/content/en/examples/if.md
+++ b/content/en/examples/if.md
@@ -35,3 +35,5 @@ fn main() {
     }
 }
 ```
+
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27uskdebug%3A%3APWTraitXqfn%20mainY%20(~letj%3A%20u8%20%3D%202Vletx%3D%20trueX~ifx%26%26j%20%3E%200%20ZLets%20code%27%3Ay%20elskZGreat%20things%20arkcomingyq)%27~qzzz%20%20y%22.pWYV)x%20is_awesomkq%5Cnke%20j%20versionZ(~zz%22Y%7B%7DX%3BqWrintV%3B~%01VWXYZjkqxyz~_>)

--- a/content/en/examples/loop.md
+++ b/content/en/examples/loop.md
@@ -33,6 +33,8 @@ fn test_main() {
 }
 ```
 
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27use%20debug%3A%3APrintTraityzfn%20mainx%20-%3Ew(z~let%20mutj%3Aw%3D%200WloopXqif_%3E%209X%20vBZconditionq~bZxW~)qvRepeating%20codeq%22hello%22.printx%3B%20qi%20%3D_%2B%201W)Wiz)%27~YYz%5Cny%3Bzx%7B%7Dw%20u128%20v%2F%2F%20qz~~_i_j%20Zreak%20Y%20%20X%20(Wy~%01WXYZ_jqvwxyz~_>)
+
 To run the test, use `cairo-test filename.cairo` or just to run it without testing use `cairo-run --single-file --available-gas 200000 filename.cairo`.
 
 For further information about this topic, check [Cairo-Book](https://cairo-book.github.io/ch02-05-control-flow.html).

--- a/content/en/examples/snapshots.md
+++ b/content/en/examples/snapshots.md
@@ -33,3 +33,5 @@ fn main() -> u32 {
     sum_starting_two(@data) // Using a snapshot instead of the mut variable
 }
 ```
+
+[Open in Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27useQMPAMSusFoptionPOptionSusFboxPBoxSjN%20ReceivesQnQMHt6VC%40GWNI5!XD%20ThiEwill%20fail%2CQEZ%20iEread-only~leYfirsYJ*K0qleYsecond%20J*K1qfirsY%2B%20secondj~N*Z%5B0%5D%20%2B%20*Z%5B1%5DDQlso%20worksj)j6main%7BWleYmuYCG%20JAMTraitPnew%7Bz1!z2!z3!z4!X~K0X~V%40Z9N%20UsingQHYinstead%20of%20thFmuYvariablej)%27~j88zX~Iq7wrap%7B7box%7BX~j%5CnZdataYt%20X%7D%3BW9-%3E%20L%20(~Vsum_starting_two%7BSTrait%3BjQ%20aP%3A%3AN%2F%2FMrrayLu32KZ.get%7BJ%3D%20IZ.append%7BH%20snapshoGAM%3CL%3EFe%20Es%20D%20%3C-CZ%3A%209%7D%208%20%207%7D.un6jfn%20!_L%01!6789CDEFGHIJKLMNPQSVWXYZjqz~_>)

--- a/content/es/examples/arrays.md
+++ b/content/es/examples/arrays.md
@@ -81,3 +81,5 @@ fn test_array_retrieve_elements() {
     // array.at(2) will cause an error
 }
 ```
+
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27hagqAgvhoptionqOptionvhboxqBoxvkfn%20main%7B%7D%20-%3EY%3Cfelt252%3E%20(~let%20mut%20j%20%3DYZqnew%7Bz444z555_k~jk)%27~kccz_~j.append%7BvZ%3Bkq%3A%3Ak%5Cnjnumbershuse%20grrayc%20%20_%7D%3BZTraitY%20Ag%01YZ_cghjkqvz~_>)

--- a/content/es/examples/clone_and_copy.md
+++ b/content/es/examples/clone_and_copy.md
@@ -27,6 +27,9 @@ fn main() {
     // foo(arr); <- fails to compile, as main doesn't own the array anymore
 }
 ```
+
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%279HNuseOVZCVN9UTCVImplNqfF_%3A%20UM%7DGfoojakRB.~xwhenKisgreturns%2CDiLdropped.q)qqfnSQGasKeOreatorYfz%2CKeSgownsB~letD%3D%20HZMZnewQN~_.cVQXxmovRPOVYfzjogcallq~_XxcompileLbecause%20previouslyB%20waLduplicated~~x_X%3C-EailsjoOompile%2CPsS%20doesn%22tYwnBPnymoreq)%27~qJJzPrrx%2F%2F%20q%5Cnj%20tgEunctioF_foo%7BarrZ%3A%3AY%20oX%7D%3B%20WezayVloneUArrayS%20mainResYwnershipYfQ%7B%7DP%20aO%20cN%3BqM%3Cu128%3ELs%20KjhJ%20%20HUTraitG%20(~xFn%20E%20fDz%20BKW9usWZ%019BDEFGHJKLMNOPQRSUVWXYZ_gjqxz~_>)
+
 Para correr ejemplo ejecuta en tu terminal `cairo-run --single-file clone_copy.cairo --available-gas 20000`
 
 Un ejemplo de derivación del trait Copy:

--- a/content/es/examples/dictionaries.md
+++ b/content/es/examples/dictionaries.md
@@ -23,3 +23,5 @@ Por defecto, se devuelve el valor `0` para claves no existentes:
         dict_felt[11] // 1024
     }
 ```
+
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27use%20dSWFeltZDSTrait%3Bjjfn%20main%7B%7D%20-%3EQZ%20(bu8zu8XbqzqZX~yu8h0YUkjOUoyu8%5BU%5DP1UO11ogP0~yqh1Y024k~gxU24j)%27~jVVzoqZ_ynewW%3CydS_x%20%2F%2FQfeltp~leRo%20%3D%20k%7D%3Bj%5Cnh.insert%7B1gyq%5B11%5DbpmuRyZ252Y%2C%201X%3E%7BkW%3A%3AV%20%20U10SictRt%20Q%20qP%3BxOpval%01OPQRSUVWXYZbghjkopqxyz~_>)

--- a/content/es/examples/enums.md
+++ b/content/es/examples/enums.md
@@ -46,4 +46,7 @@ fn my_enum_get_b(x: MyEnum) -> Option::<u16> {
     }
 }
 ```
+
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27use%20optionkWTrait0use%20debugkPr!tTrait0ZDef!e5qenum%20YRAJu8LBJu16LCJu32LDJu64q)qZIKwill%20pr!KUqfn%20ma!XRleKx9VaX0~leKy9Vget_bF%7D0~mHyR~WkSomeFj%22GoKB%22.pr!tXL~*jU.pr!tXL)%20q)qZConstrucKand%20return5%20variant.qfnVaX%20-7YRYkA%7B4_u8%7Dq)qZMHtheQ%2C%20the%20order%20musKmHtheQ%20def!ition.ZW%20is%20also5.qfnVget_bFJY%7D%20-7Wk%3Cu16%3ERmHxR~YkAz~YkBFjWkSomeF%7DL~YkCz~YkDz)q)%27~%20%20%20%20zFj*%7DLq%5Cnk%3A%3Aj%7D97Zq%2F%2F%20YMyEnumX%7B%7DWOptionV%20my_enum_U%22GoKsometh!g%20else%22R%20(q~Q%20enumL%2Cq~Kt%20J%3A%20Hatch%20F%7Bx9%20%3D7%3E%205%20anQ0%3Bq*WkNone%7BX!in%01!*0579FHJKLQRUVWXYZjkqz~_>)
+
 Para correr el ejemplo simplemente ejecute `cairo-run --single-file enums.cairo` en su terminal.

--- a/content/es/examples/if.md
+++ b/content/es/examples/if.md
@@ -35,3 +35,5 @@ fn main() {
     }
 }
 ```
+
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27uskdebug%3A%3APWTraitXqfn%20mainY%20(~letj%3A%20u8%20%3D%202Vletx%3D%20trueX~ifx%26%26j%20%3E%200%20ZLets%20code%27%3Ay%20elskZGreat%20things%20arkcomingyq)%27~qzzz%20%20y%22.pWYV)x%20is_awesomkq%5Cnke%20j%20versionZ(~zz%22Y%7B%7DX%3BqWrintV%3B~%01VWXYZjkqxyz~_>)

--- a/content/es/examples/loop.md
+++ b/content/es/examples/loop.md
@@ -33,6 +33,8 @@ fn test_main() {
 }
 ```
 
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27use%20debug%3A%3APrintTraityzfn%20mainx%20-%3Ew(z~let%20mutj%3Aw%3D%200WloopXqif_%3E%209X%20vBZconditionq~bZxW~)qvRepeating%20codeq%22hello%22.printx%3B%20qi%20%3D_%2B%201W)Wiz)%27~YYz%5Cny%3Bzx%7B%7Dw%20u128%20v%2F%2F%20qz~~_i_j%20Zreak%20Y%20%20X%20(Wy~%01WXYZ_jqvwxyz~_>)
+
 Para ejecutar la prueba, use `cairo-test nombre-de-archivo.cairo` o simplemente para ejecutarla sin probar use `cairo-run --single-file --available-gas 200000 nombre-de-archivo.cairo`.
 
 Para más información sobre este tema, consulte [Cairo-Book](https://cairo-book.github.io/ch02-05-control-flow.html).

--- a/content/es/examples/snapshots.md
+++ b/content/es/examples/snapshots.md
@@ -33,3 +33,5 @@ fn main() -> u32 {
     sum_starting_two(@data) // Using a snapshot instead of the mut variable
 }
 ```
+
+[Abierto en Cairo Playground](<https://cairovm.codes/?codeType=Cairo&code=%27useQMPAMSusFoptionPOptionSusFboxPBoxSjN%20ReceivesQnQMHt6VC%40GWNI5!XD%20ThiEwill%20fail%2CQEZ%20iEread-only~leYfirsYJ*K0qleYsecond%20J*K1qfirsY%2B%20secondj~N*Z%5B0%5D%20%2B%20*Z%5B1%5DDQlso%20worksj)j6main%7BWleYmuYCG%20JAMTraitPnew%7Bz1!z2!z3!z4!X~K0X~V%40Z9N%20UsingQHYinstead%20of%20thFmuYvariablej)%27~j88zX~Iq7wrap%7B7box%7BX~j%5CnZdataYt%20X%7D%3BW9-%3E%20L%20(~Vsum_starting_two%7BSTrait%3BjQ%20aP%3A%3AN%2F%2FMrrayLu32KZ.get%7BJ%3D%20IZ.append%7BH%20snapshoGAM%3CL%3EFe%20Es%20D%20%3C-CZ%3A%209%7D%208%20%207%7D.un6jfn%20!_L%01!6789CDEFGHIJKLMNPQSVWXYZjqz~_>)


### PR DESCRIPTION
Added `Open in Cairo Playground` links to examples for both en and es languages.
With reference to [#100](https://github.com/walnuthq/cairovm.codes/issues/100#issue-2191497456)